### PR TITLE
Execute workloads based on labels instead of flags in PR titles

### DIFF
--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Add comment about missing build-dependency-containers label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v4
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
@@ -52,7 +52,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Add label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v4
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -54,7 +54,7 @@ jobs:
 
   add-label-missing-comment:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'unlabeled') && contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
     steps:
     - uses: actions/checkout@v2
     - name: Add comment about missing build-dependency-containers label

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -18,6 +18,8 @@ on:
     - build/containers/intermediate/Dockerfile.opencvsharp-build
     - build/intermediate-containers.mk
     - Makefile
+  pull_request_review_comment:
+    types: [created]
 
 env:
   AKRI_COMPONENT: opencvsharp-build
@@ -25,9 +27,51 @@ env:
 
 jobs:
 
+  add-label-missing-comment:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add comment about missing build-dependency-containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'hey this apparently should run but running it will take hours. Do you want to run it? If so, add flag build deps cont. (also tags Akri Maintainers)'
+          })
+          exit 1
+
+  add-build-label-to-pr:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '/add-build-dependency-containers') && github.event_name == 'pull_request_review_comment'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['build-dependency-containers']
+          })
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Added build-dependency-containers label :)!'
+          })
+
   per-arch:
-    if: >-
-      contains(github.event.pull_request.labels.*.name, 'ignore intermediate builds') == false
+    if: contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == true
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,15 +84,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-
-    - name: Akri intermediate builds are LONG running and should only be run when absolutely needed
-      if: >-
-        contains(github.event.pull_request.labels.*.name, 'allow intermediate builds') == false
-      run: |
-        echo "Akri intermediate builds are LONG running and should only be run when absolutely needed."
-        echo "Add [IGNORE INTERMEDIATE BUILDS] to first commit message to skip building intermediate containers."
-        echo "Add [ALLOW INTERMEDIATE BUILDS] to first commit message if needed."
-        exit 1
 
     # Only run build version change check if PR does not have "same version" label
     - if: >-

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -18,8 +18,9 @@ on:
     - build/containers/intermediate/Dockerfile.opencvsharp-build
     - build/intermediate-containers.mk
     - Makefile
-  pull_request_review_comment:
+  issue_comment:
     types: [created]
+    branches: [ main ]
 
 env:
   AKRI_COMPONENT: opencvsharp-build
@@ -27,47 +28,46 @@ env:
 
 jobs:
 
-  add-label-missing-comment:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
-    steps:
-    - uses: actions/checkout@v2
-    - name: Add comment about missing build-dependency-containers label
-      uses: actions/github-script@v4
-      if: success()
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.issues.createComment({
-            issue_number: context.payload.pull_request.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'hey this apparently should run but running it will take hours. Do you want to run it? If so, add flag build deps cont. (also tags Akri Maintainers)'
-          })
-          exit 1
-
   add-build-label-to-pr:
     runs-on: ubuntu-latest
-    if: contains(github.event.comment.body, '/add-build-dependency-containers') && github.event_name == 'pull_request_review_comment'
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-build-dependency-containers')
     steps:
     - uses: actions/checkout@v2
-    - name: Add label
-      uses: actions/github-script@v4
+    - name: Add build-dependency-containers label
+      uses: actions/github-script@0.9.0
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           github.issues.addLabels({
-            issue_number: context.payload.pull_request.number,
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             labels: ['build-dependency-containers']
           })
           github.issues.createComment({
-            issue_number: context.payload.pull_request.number,
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: '👋 Added build-dependency-containers label :)!'
+          })
+
+  add-label-missing-comment:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add comment about missing build-dependency-containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Hi there, this change should run a build dependency containers, but running it will take hours. Do you want to run it? If so, please add flag build-dependency-containers by commenting "/add-build-dependency-containers".'
           })
 
   per-arch:

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -10,7 +10,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request:
-  types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -19,7 +19,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   issue_comment:
-    types: [created]
+    types: [created, edited]
     branches: [ main ]
 
 env:

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -10,6 +10,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request:
+  types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
@@ -26,8 +27,7 @@ jobs:
 
   per-arch:
     if: >-
-      !contains(github.event.pull_request.title, '[IGNORE INTERMEDIATE BUILDS]') &&
-      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]')
+      contains(github.event.pull_request.labels.*.name, 'ignore intermediate builds') == false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,19 +43,17 @@ jobs:
 
     - name: Akri intermediate builds are LONG running and should only be run when absolutely needed
       if: >-
-        !contains(github.event.pull_request.title, '[ALLOW INTERMEDIATE BUILDS]') &&
-        !contains(github.event.commits[0].message, '[ALLOW INTERMEDIATE BUILDS]')
+        contains(github.event.pull_request.labels.*.name, 'allow intermediate builds') == false
       run: |
         echo "Akri intermediate builds are LONG running and should only be run when absolutely needed."
         echo "Add [IGNORE INTERMEDIATE BUILDS] to first commit message to skip building intermediate containers."
         echo "Add [ALLOW INTERMEDIATE BUILDS] to first commit message if needed."
         exit 1
 
-    # Only run build version change check if PR title and Merge commit message do NOT contain "[SAME VERSION]"
+    # Only run build version change check if PR does not have "same version" label
     - if: >-
         startsWith(github.event_name, 'pull_request') &&
-        !contains(github.event.pull_request.title, '[SAME VERSION]') &&
-        !contains(github.event.commits[0].message, '[SAME VERSION]')
+        contains(github.event.pull_request.labels.*.name, 'same version') == false
       name: Ensure that ${{ env.AKRI_COMPONENT }} version has changed
       run: |
         git fetch origin main

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -54,7 +54,7 @@ jobs:
 
   add-label-missing-comment:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'unlabeled') && contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
     steps:
     - uses: actions/checkout@v2
     - name: Add comment about missing build-dependency-containers label

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Add comment about missing build-dependency-containers label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v4
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
@@ -50,7 +50,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Add label
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v4
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -10,6 +10,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request:
+  types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
@@ -26,8 +27,7 @@ jobs:
 
   per-arch:
     if: >-
-      !contains(github.event.pull_request.title, '[IGNORE INTERMEDIATE BUILDS]') &&
-      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]')
+      contains(github.event.pull_request.labels.*.name, 'ignore intermediate builds') == false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,19 +43,17 @@ jobs:
 
     - name: Akri intermediate builds are LONG running and should only be run when absolutely needed
       if: >-
-        !contains(github.event.pull_request.title, '[ALLOW INTERMEDIATE BUILDS]') &&
-        !contains(github.event.commits[0].message, '[ALLOW INTERMEDIATE BUILDS]')
+        contains(github.event.pull_request.labels.*.name, 'allow intermediate builds') == false
       run: |
         echo "Akri intermediate builds are LONG running and should only be run when absolutely needed."
-        echo "Add [IGNORE INTERMEDIATE BUILDS] to first commit message to skip building intermediate containers."
-        echo "Add [ALLOW INTERMEDIATE BUILDS] to first commit message if needed."
+        echo "Add 'ignore intermediate builds' label to the PR to skip building intermediate containers."
+        echo "Add 'allow intermediate builds' label to the PR if needed."
         exit 1
 
-    # Only run build version change check if PR title and Merge commit message do NOT contain "[SAME VERSION]"
+    # Only run build version change check if PR does not have "same version" label
     - if: >-
         startsWith(github.event_name, 'pull_request') &&
-        !contains(github.event.pull_request.title, '[SAME VERSION]') &&
-        !contains(github.event.commits[0].message, '[SAME VERSION]')
+        contains(github.event.pull_request.labels.*.name, 'same version') == false
       name: Ensure that ${{ env.AKRI_COMPONENT }} version has changed
       run: |
         git fetch origin main

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -10,7 +10,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request:
-  types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -19,7 +19,7 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   issue_comment:
-    types: [created]
+    types: [created, edited]
     branches: [ main ]
 
 env:

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -18,6 +18,9 @@ on:
     - build/containers/intermediate/Dockerfile.rust-crossbuild-*
     - build/intermediate-containers.mk
     - Makefile
+  issue_comment:
+    types: [created]
+    branches: [ main ]
 
 env:
   AKRI_COMPONENT: rust-crossbuild
@@ -25,47 +28,46 @@ env:
 
 jobs:
 
-  add-label-missing-comment:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
-    steps:
-    - uses: actions/checkout@v2
-    - name: Add comment about missing build-dependency-containers label
-      uses: actions/github-script@v4
-      if: success()
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.issues.createComment({
-            issue_number: context.payload.pull_request.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'hey this apparently should run but running it will take hours. Do you want to run it? If so, add flag build deps cont to your PR by adding this comment: "/add-build-dependency-containers"'
-          })
-          exit 1
-
   add-build-label-to-pr:
     runs-on: ubuntu-latest
-    if: contains(github.event.comment.body, '/add-build-dependency-containers') && github.event_name == 'pull_request_review_comment'
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/add-build-dependency-containers')
     steps:
     - uses: actions/checkout@v2
-    - name: Add label
-      uses: actions/github-script@v4
+    - name: Add build-dependency-containers label
+      uses: actions/github-script@0.9.0
       if: success()
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           github.issues.addLabels({
-            issue_number: context.payload.pull_request.number,
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             labels: ['build-dependency-containers']
           })
           github.issues.createComment({
-            issue_number: context.payload.pull_request.number,
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: '👋 Added build-dependency-containers label :)!'
+          })
+
+  add-label-missing-comment:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add comment about missing build-dependency-containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Hi there, this change should run a build dependency containers, but running it will take hours. Do you want to run it? If so, please add flag build-dependency-containers by commenting "/add-build-dependency-containers".'
           })
 
   per-arch:

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -25,9 +25,51 @@ env:
 
 jobs:
 
+  add-label-missing-comment:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add comment about missing build-dependency-containers label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'hey this apparently should run but running it will take hours. Do you want to run it? If so, add flag build deps cont to your PR by adding this comment: "/add-build-dependency-containers"'
+          })
+          exit 1
+
+  add-build-label-to-pr:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '/add-build-dependency-containers') && github.event_name == 'pull_request_review_comment'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add label
+      uses: actions/github-script@0.9.0
+      if: success()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['build-dependency-containers']
+          })
+          github.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Added build-dependency-containers label :)!'
+          })
+
   per-arch:
-    if: >-
-      contains(github.event.pull_request.labels.*.name, 'ignore intermediate builds') == false
+    if: contains(github.event.pull_request.labels.*.name, 'build-dependency-containers') == true
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,15 +82,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-
-    - name: Akri intermediate builds are LONG running and should only be run when absolutely needed
-      if: >-
-        contains(github.event.pull_request.labels.*.name, 'allow intermediate builds') == false
-      run: |
-        echo "Akri intermediate builds are LONG running and should only be run when absolutely needed."
-        echo "Add 'ignore intermediate builds' label to the PR to skip building intermediate containers."
-        echo "Add 'allow intermediate builds' label to the PR if needed."
-        exit 1
 
     # Only run build version change check if PR does not have "same version" label
     - if: >-

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -19,6 +19,7 @@ on:
       - scripts/**
       - tests/**
   pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches: [ main ]
     paths-ignore:
       - '.gitignore'
@@ -38,6 +39,9 @@ on:
   release:
     types:
       - published
+  issues:
+    types:
+      - labeled
 
 env:
   CARGO_TERM_COLOR: always
@@ -52,14 +56,14 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    
-    # Only run version check for PRs.  If PR title does NOT contain "[SAME VERSION]", then ensure that
+
+    # Only run version check for PRs. If PR does NOT have "same version" label, then ensure that
     # version.txt is different from what is in main.
-    - if: startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.title, '[SAME VERSION]') == false
-      name: Run version check
+    - if: startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.labels.*.name, 'same version') == false
+      name: Run version check (triggered by "same version" label)
       run: ./version.sh -c
-    # If PR title does contain "[SAME VERSION]", then do not check that version.txt is different from
+    # If PR does have "same version" label, then do not check that version.txt is different from
     # what is in main.
-    - if: startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.title, '[SAME VERSION]') == true
-      name: Run version check
+    - if: startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.labels.*.name, 'same version') == true
+      name: Run version check (skip, triggered by "same version" label)
       run: ./version.sh -c -s


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Currently, certain workflows are being skipped/executed based on flags set in PR titles. For example, adding [SAME VERSION] to a PR title prevents the version check workflow from running. However, after adding a flag to a title, checks cannot simply be re-run, since they refer to the state of the PR of the last commit. Resultingly, another commit must be pushed to the PR in order for checks to properly register the PR title change (and therefore flag). Running workflows based on labels instead of flags may remove this issue of pushing new commits. This change enables running build/version check based on labels. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)